### PR TITLE
Add Code Coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
 
       - run:
           name: install dependencies
@@ -33,4 +31,12 @@ jobs:
       - run:
           name: run tests
           command: |
-            rake
+            bundle exec rake
+
+      - run:
+          name: Upload Code Coverage
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+            ./cc-test-reporter format-coverage
+            ./cc-test-reporter upload-coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cloudapp-export (0.2.2)
-      dotenv (= 2.2.1)
+      dotenv (= 2.5.0)
       net-http-digest_auth (= 1.4.1)
       thor (= 0.20.0)
 
@@ -10,25 +10,27 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    dotenv (2.2.1)
+    dotenv (2.5.0)
+    jaro_winkler (1.5.1)
     minitest (5.11.3)
     net-http-digest_auth (1.4.1)
     parallel (1.12.1)
-    parser (2.5.0.5)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     rainbow (3.0.0)
     rake (12.3.1)
-    rubocop (0.54.0)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     thor (0.20.0)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
@@ -38,7 +40,7 @@ DEPENDENCIES
   cloudapp-export!
   minitest (~> 5.11)
   rake (~> 12.3)
-  rubocop (~> 0.54.0)
+  rubocop (~> 0.59.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    docile (1.3.1)
     dotenv (2.5.0)
     jaro_winkler (1.5.1)
+    json (2.1.0)
     minitest (5.11.3)
     net-http-digest_auth (1.4.1)
     parallel (1.12.1)
@@ -29,6 +31,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     thor (0.20.0)
     unicode-display_width (1.4.0)
 
@@ -41,6 +48,7 @@ DEPENDENCIES
   minitest (~> 5.11)
   rake (~> 12.3)
   rubocop (~> 0.59.2)
+  simplecov (~> 0.16.1)
 
 BUNDLED WITH
    1.16.4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # CloudApp Export
 
+[![CircleCI](https://circleci.com/gh/marcqualie/cloudapp-export.svg?style=svg)](https://circleci.com/gh/marcqualie/cloudapp-export)
+[![Maintainability](https://api.codeclimate.com/v1/badges/1a0c70e2d6043ef9570a/maintainability)](https://codeclimate.com/github/marcqualie/cloudapp-export/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/1a0c70e2d6043ef9570a/test_coverage)](https://codeclimate.com/github/marcqualie/cloudapp-export/test_coverage)
+
 A quick way to grab all the data you have stored in [CloudApp](https://www.getcloudapp.com/).
 
 

--- a/cloudapp-export.gemspec
+++ b/cloudapp-export.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.3"
 
-  spec.add_dependency "dotenv", "2.2.1"
+  spec.add_dependency "dotenv", "2.5.0"
   spec.add_dependency "net-http-digest_auth", "1.4.1"
   spec.add_dependency "thor", "0.20.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rubocop", "~> 0.54.0"
+  spec.add_development_dependency "rubocop", "~> 0.59.2"
   spec.add_development_dependency "minitest", "~> 5.11"
 end

--- a/cloudapp-export.gemspec
+++ b/cloudapp-export.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "0.20.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rubocop", "~> 0.59.2"
-  spec.add_development_dependency "minitest", "~> 5.11"
+  spec.add_development_dependency "simplecov", "~> 0.16.1"
 end

--- a/lib/cloudapp_export/api.rb
+++ b/lib/cloudapp_export/api.rb
@@ -15,6 +15,7 @@ module CloudappExport
     def authenticate!
       response = request("items?per_page=1")
       return true if response.status_code == 200
+
       # TODO: Use custom exception classes
       raise response.body.strip
     end

--- a/lib/cloudapp_export/exporter.rb
+++ b/lib/cloudapp_export/exporter.rb
@@ -64,6 +64,7 @@ module CloudappExport
     def item_filesize_human(item)
       filesize = item_filesize(item)
       return '--' if filesize.zero?
+
       size_human(filesize)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require "simplecov"
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "cloudapp_export"
 


### PR DESCRIPTION
Coverage details: https://codeclimate.com/github/marcqualie/cloudapp-export

Outdated gems included in the bundle:
  * dotenv (newest 2.5.0, installed 2.2.1)
  * parser (newest 2.5.1.2, installed 2.5.0.5)
  * powerpack (newest 0.1.2, installed 0.1.1)
  * rubocop (newest 0.59.2, installed 0.54.0, requested ~> 0.54.0) in groups "development"
  * ruby-progressbar (newest 1.10.0, installed 1.9.0)
  * unicode-display_width (newest 1.4.0, installed 1.3.0)